### PR TITLE
Fix 64-bit tagged pointer issue.

### DIFF
--- a/NSNumber+SexyDates.m
+++ b/NSNumber+SexyDates.m
@@ -124,7 +124,18 @@ static char SEXY_DATES_COMPONENTS_KEY;
 }
 
 - (NSDateComponents *)sexyDates_dateComponents {
-    NSDateComponents *components = objc_getAssociatedObject(self, &SEXY_DATES_COMPONENTS_KEY);
+    static NSMapTable *hashTable = nil;
+    if (!hashTable) {
+        hashTable = [[NSMapTable alloc] init];
+    }
+
+    NSString *hash = [hashTable objectForKey:self];
+    if (!hash) {
+        hash = [NSString stringWithFormat:@"%lu", (unsigned long)self.hash];
+        [hashTable setObject:hash forKey:self];
+    }
+    
+    NSDateComponents *components = objc_getAssociatedObject(hash, &SEXY_DATES_COMPONENTS_KEY);
     
     if (!components) {
         components = [[NSDateComponents alloc] init];
@@ -137,7 +148,7 @@ static char SEXY_DATES_COMPONENTS_KEY;
         components.month  = 0;
         components.year   = 0;
         
-        objc_setAssociatedObject(self,
+        objc_setAssociatedObject(hash,
                                  &SEXY_DATES_COMPONENTS_KEY,
                                  components,
                                  OBJC_ASSOCIATION_RETAIN_NONATOMIC);


### PR DESCRIPTION
Use NSNumber self pointer as a key for distinguished value storage.
Get/set associated object with unique value.
